### PR TITLE
pass options to the engines from ecto

### DIFF
--- a/src/ecto.ts
+++ b/src/ecto.ts
@@ -16,14 +16,25 @@ export class Ecto {
 	private __defaultEngine = 'ejs';
 
 	// Engines
-	private readonly __ejs: EJS = new EJS();
-	private readonly __markdown: Markdown = new Markdown();
-	private readonly __pug: Pug = new Pug();
-	private readonly __nunjucks: Nunjucks = new Nunjucks();
-	private readonly __handlebars: Handlebars = new Handlebars();
-	private readonly __liquid: Liquid = new Liquid();
+	private readonly __ejs: EJS;
+	private readonly __markdown: Markdown;
+	private readonly __pug: Pug;
+	private readonly __nunjucks: Nunjucks;
+	private readonly __handlebars: Handlebars;
+	private readonly __liquid: Liquid;
 
-	constructor(options?: any) {
+	constructor(options?: Record<string, unknown>) {
+		const engineOptions = {...options};
+		delete engineOptions.defaultEngine;
+
+		// Engines
+		this.__ejs = new EJS(engineOptions);
+		this.__markdown = new Markdown(engineOptions);
+		this.__pug = new Pug(engineOptions);
+		this.__nunjucks = new Nunjucks(engineOptions);
+		this.__handlebars = new Handlebars(engineOptions);
+		this.__liquid = new Liquid(engineOptions);
+
 		// Register engines
 		this.__engines.push(this.__ejs, this.__markdown, this.__pug, this.__nunjucks, this.__handlebars, this.__liquid);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Followed the [Contributing](https://github.com/jaredwray/ecto/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Currently, `ecto` receives an `options` object, but these options are not being passed to the template engines. As a result, the engines cannot be customized or configured.

```
export class Ecto {
	private readonly __mapping: EngineMap = new EngineMap();
	private readonly __engines: BaseEngine[] = new Array<BaseEngine>();

	private __defaultEngine = 'ejs';

	// Engines
	private readonly __ejs: EJS = new EJS();
	private readonly __markdown: Markdown = new Markdown();
	private readonly __pug: Pug = new Pug();
	private readonly __nunjucks: Nunjucks = new Nunjucks();
	private readonly __handlebars: Handlebars = new Handlebars();
	private readonly __liquid: Liquid = new Liquid();
}
```
