### PR TITLE
fix: respect disabled cache options

### DIFF
--- a/src/ecto.ts
+++ b/src/ecto.ts
@@ -99,25 +99,19 @@ export class Ecto extends Hookified {
 		this.registerEngineMappings();
 
 		// Set the cacheable instance if caching is enabled
-		if (options?.cache !== undefined) {
-			// eslint-disable-next-line unicorn/prefer-ternary
-			if (typeof options.cache === 'boolean') {
-				// Set with default options
-				this.__cache = new Cacheable();
-			} else {
-				this.__cache = options.cache;
-			}
+		if (options?.cache === true) {
+			// Set with default options
+			this.__cache = new Cacheable();
+		} else if (options?.cache instanceof Cacheable) {
+			this.__cache = options.cache;
 		}
 
 		// Set the cacheable memory instance if caching is enabled
-		if (options?.cacheSync !== undefined) {
-			// eslint-disable-next-line unicorn/prefer-ternary
-			if (typeof options.cacheSync === 'boolean') {
-				// Set with default options
-				this.__cacheSync = new CacheableMemory();
-			} else {
-				this.__cacheSync = options.cacheSync;
-			}
+		if (options?.cacheSync === true) {
+			// Set with default options
+			this.__cacheSync = new CacheableMemory();
+		} else if (options?.cacheSync instanceof CacheableMemory) {
+			this.__cacheSync = options.cacheSync;
 		}
 
 		// Set the options

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -93,3 +93,13 @@ it('render via ejs hello from docs with caching disabled', () => {
 	const data = {firstName: 'John', lastName: 'Doe'};
 	expect(ecto.renderSync(source, data)).toBe('<h1>Hello John Doe!</h1>');
 });
+
+it('cache should remain disabled when explicitly set to false', () => {
+	const ecto = new Ecto({cache: false});
+	expect(ecto.cache).toBe(undefined);
+});
+
+it('cacheSync should remain disabled when explicitly set to false', () => {
+	const ecto = new Ecto({cacheSync: false});
+	expect(ecto.cacheSync).toBe(undefined);
+});


### PR DESCRIPTION
## Summary
- ensure cache and cacheSync options only enable caching when truthy or supplied with instances
- test that cache options remain disabled when explicitly false

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689f7f3122ac8324a96529944e2c1584