### PR TITLE
Fix: add Handlebars renderFromFile partial tests and auto root inference

### DIFF
--- a/src/ecto.ts
+++ b/src/ecto.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { Cacheable, CacheableMemory } from "cacheable";
 import { Hookified, type HookifiedOptions } from "hookified";
 import { Writr } from "writr";
@@ -387,6 +388,8 @@ export class Ecto extends Hookified {
 		// Select which engine
 		engineName ??= this.getEngineByFilePath(filePath);
 
+		const templateRootPath = rootTemplatePath ?? path.dirname(filePath);
+
 		// Get the source
 		const source = await fs.promises.readFile(filePath, "utf8");
 
@@ -394,7 +397,7 @@ export class Ecto extends Hookified {
 			source,
 			data,
 			engineName,
-			rootTemplatePath,
+			templateRootPath,
 			filePathOutput,
 		);
 
@@ -422,6 +425,8 @@ export class Ecto extends Hookified {
 		// Select which engine
 		engineName ??= this.getEngineByFilePath(filePath);
 
+		const templateRootPath = rootTemplatePath ?? path.dirname(filePath);
+
 		// Get the source
 		const source = fs.readFileSync(filePath, "utf8");
 
@@ -429,7 +434,7 @@ export class Ecto extends Hookified {
 			source,
 			data,
 			engineName,
-			rootTemplatePath,
+			templateRootPath,
 			filePathOutput,
 		);
 

--- a/test/ecto.test.ts
+++ b/test/ecto.test.ts
@@ -385,6 +385,30 @@ it("Render from Template - Handlebars", async () => {
 	expect(source).toContain("Foo!");
 });
 
+it("Render from Template - Handlebars infers root path for partials", async () => {
+	const ecto = new Ecto();
+	const source = await ecto.renderFromFile(
+		`${testRootDirectory}/handlebars/example1.hbs`,
+		handlebarsExampleData,
+	);
+
+	expect(source).toContain("<title>Alan O'Connor - Header Title </title>");
+	expect(source).toContain("Foo!");
+	expect(source).toContain("ux layout");
+});
+
+it("Render from Template - Handlebars infers root path for partials synchronously", () => {
+	const ecto = new Ecto();
+	const source = ecto.renderFromFileSync(
+		`${testRootDirectory}/handlebars/example1.hbs`,
+		handlebarsExampleData,
+	);
+
+	expect(source).toContain("<title>Alan O'Connor - Header Title </title>");
+	expect(source).toContain("Foo!");
+	expect(source).toContain("ux layout");
+});
+
 it("Find Template without Extension", async () => {
 	const ecto = new Ecto();
 	const templatePath = `${testRootDirectory}/find-templates`;


### PR DESCRIPTION
## Summary
- add coverage for Handlebars renderFromFile and renderFromFileSync partial rendering without specifying a root
- infer the template root directory from the template path when one is not provided so partial discovery succeeds

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cc966bc8288324ac8fe7338aacc58d