### PR TITLE
ecto - chore: upgrade vitest and coverage-v8 to ^4.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,13 +69,13 @@
     "@types/node": "^24.0.15",
     "@types/nunjucks": "^3.2.6",
     "@types/pug": "^2.0.10",
-    "@vitest/coverage-v8": "^4.1.3",
+    "@vitest/coverage-v8": "^4.1.5",
     "docula": "^1.14.0",
     "rimraf": "^6.1.3",
     "tsdown": "^0.21.7",
     "typescript": "^6.0.3",
     "vite": "^8.0.5",
-    "vitest": "^4.1.3"
+    "vitest": "^4.1.5"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary
Upgrade test tooling to latest patch versions.

## Versions
- `@vitest/coverage-v8` `^4.1.3` → `^4.1.5`
- `vitest` `^4.1.3` → `^4.1.5`

> **Note:** `@biomejs/biome` was reverted to `^2.4.10` — version 2.4.15 was published <48 hours ago and is blocked by `minimumReleaseAge: 2880` in `pnpm-workspace.yaml`. It will be bumped in a follow-up PR once it ages out.

> Replaces #351 (closed due to irreconcilable adjacent-line merge conflict from accumulated sync commits).

## Tests
- [ ] `pnpm test` passes
- [ ] `pnpm build` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_0184GyjNucmQQsUDpRCCLaNs)_