### PR TITLE
ecto - chore: upgrade cacheable to ^2.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   ],
   "dependencies": {
     "@jaredwray/fumanchu": "^4.6.1",
-    "cacheable": "^2.3.4",
+    "cacheable": "^2.3.5",
     "ejs": "^5.0.2",
     "ent": "^2.2.2",
     "hookified": "^2.1.1",


### PR DESCRIPTION
## Summary\nUpgrade cacheable to latest patch version.\n\n## Versions\n- `cacheable` `^2.3.4` → `^2.3.5`\n\n> Replaces #356 (closed due to adjacent-line merge conflict from accumulated sync commits).\n\n## Tests\n- [ ] `pnpm test` passes\n- [ ] `pnpm build` passes\n\n---\n_Generated by [Claude Code](https://claude.ai/code/session_0184GyjNucmQQsUDpRCCLaNs)_