### PR TITLE
ecto - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -36,7 +36,7 @@ jobs:
       run: pnpm test
 
     - name: Code Coverage
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_KEY }}
         files: ./coverage/lcov.info

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -36,7 +36,7 @@ jobs:
       run: pnpm website:build
 
     - name: Publish to Cloudflare Pages
-      uses: cloudflare/wrangler-action@v3
+      uses: cloudflare/wrangler-action@v4
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         command: pages deploy site/dist --project-name=ecto --branch=main


### PR DESCRIPTION
## Summary
Upgrade GitHub Actions with major version bumps for Node 24 runtime and Wrangler v4 support.

## Versions
- `codecov/codecov-action` `v5` → `v6` (Node 24 runtime requirement — already satisfied)
- `cloudflare/wrangler-action` `v3` → `v4` (defaults to Wrangler v4; `pages deploy` command unchanged)

## Tests
- [x] Workflow YAML parses correctly

## Breaking notes
- `codecov-action@v6` requires Node.js 24 on the GitHub Actions runner (mandatory after June 2, 2026)
- `wrangler-action@v4` defaults to Wrangler CLI v4; no input changes needed for `pages deploy` usage

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9g68hZHCuJKuSeES6fnrt)_