### PR TITLE
ecto - chore: harden pnpm-workspace.yaml with supply chain controls

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,11 @@
-minimumReleaseAge: 2880
+minimumReleaseAge: 10080
+minimumReleaseAgeStrict: true
+minimumReleaseAgeIgnoreMissingTime: false
+blockExoticSubdeps: true
+strictDepBuilds: true
+dangerouslyAllowAllBuilds: false
+trustPolicy: no-downgrade
+
 allowBuilds:
   esbuild: true
   unrs-resolver: true


### PR DESCRIPTION
## Summary
Apply agentic defense-in-depth Section 4 recommended baseline to `pnpm-workspace.yaml`.

## Changes
- `minimumReleaseAge` `2880` → `10080` (7 days, up from 2 days)
- Added `minimumReleaseAgeStrict: true` — resolution fails instead of falling back to too-new versions
- Added `minimumReleaseAgeIgnoreMissingTime: false` — missing publish-time metadata fails closed
- Added `blockExoticSubdeps: true` — blocks exotic subdependency sources
- Added `strictDepBuilds: true` — strict lifecycle script control
- Added `dangerouslyAllowAllBuilds: false` — explicit denial of unchecked build scripts
- Added `trustPolicy: no-downgrade`
- Preserved existing `allowBuilds` entries (esbuild, unrs-resolver, @biomejs/biome, workerd)

## Verification
- [x] `pnpm install --frozen-lockfile` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (237 tests, 100% coverage)

## Reference
defense-in-depth-nodejs.md § 4

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9g68hZHCuJKuSeES6fnrt)_