### PR TITLE
ecto - fix: add CLOUDFLARE_ACCOUNT_ID to deploy workflow

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -39,4 +39,5 @@ jobs:
       uses: cloudflare/wrangler-action@v4
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         command: pages deploy site/dist --project-name=ecto --branch=main


### PR DESCRIPTION
## Summary
Add `CLOUDFLARE_ACCOUNT_ID` secret to the wrangler-action step in the deploy-site workflow. Required for Cloudflare Pages deployment authentication alongside the API token.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9g68hZHCuJKuSeES6fnrt)_